### PR TITLE
change the python version in github action ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
         if: runner.os == 'macos' && matrix.target.cpu == 'amd64'
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7.17
+          python-version: pypy-2.7
 
       - name: Setup and run Autobahn test suite.
         if: runner.os == 'macos' && matrix.target.cpu == 'amd64'


### PR DESCRIPTION
from: 2.7.17 to pypy-2.7

why:
there is annoying warning message in github action ci:

DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020.
Please upgrade your Python as Python 2.7 won't be maintained after that date.
A future version of pip will drop support for Python 2.7.
More details about Python 2 support in pip, can be found at
https://pip.pypa.io/en/latest/development/release-process/#python-2-support