### PR TITLE
Fix autobahn tls tests

### DIFF
--- a/ws.nimble
+++ b/ws.nimble
@@ -15,11 +15,11 @@ requires "nimcrypto"
 requires "bearssl"
 
 task test, "run tests":
-  exec "nim c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testcommon.nim"
+  exec "nim --hints:off c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testcommon.nim"
   rmFile "./tests/testcommon"
 
-  exec "nim c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testwebsockets.nim"
+  exec "nim --hints:off c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testwebsockets.nim"
   rmFile "./tests/testwebsockets"
 
-  exec "nim -d:secure c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testwebsockets.nim"
+  exec "nim --hints:off -d:secure c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testwebsockets.nim"
   rmFile "./tests/testwebsockets"

--- a/ws/http/common.nim
+++ b/ws/http/common.nim
@@ -51,9 +51,9 @@ proc closeStream*(stream: AsyncStreamRW) {.async.} =
 
 proc closeWait*(stream: AsyncStream) {.async.} =
   await allFutures(
-    stream.reader.tsource.closeTransp(),
     stream.reader.closeStream(),
-    stream.writer.closeStream())
+    stream.writer.closeStream(),
+    stream.reader.tsource.closeTransp())
 
 proc sendResponse*(
   request: HttpRequest,


### PR DESCRIPTION
This PR attempts to address erratic behaviour under TLS, where the close code/reason aren't sent out if the socket is closed right after calling `stream.write()`. This behavior doesn't manifest for regular (non-tls) connections and currently only worked around with a `sleepAsync(10.millis)` - this workaround should be temporary and the root cause should be investigated.