### PR TITLE
Fix mutual closing

### DIFF
--- a/ws/session.nim
+++ b/ws/session.nim
@@ -145,7 +145,7 @@ proc handleClose*(
 
   trace "Handling close"
 
-  if ws.readyState != ReadyState.Open:
+  if ws.readyState != ReadyState.Open and ws.readyState != ReadyState.Closing:
     trace "Connection isn't open, aborting close sequence!"
     return
 


### PR DESCRIPTION
In the current version, if both parties close the session at the same time, the session get stuck.